### PR TITLE
Fix notification close symbol

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,8 @@
 .control-sheet .heavy-right {
   @apply border-r-2;
 }
+
+/* TODO: Remove when tailwind has been bumped to version => 3.0 */
+.h-fit {
+  height: fit-content;
+}

--- a/src/ui/Alert.js
+++ b/src/ui/Alert.js
@@ -28,8 +28,7 @@ export default function Alert({ message, detail, type = "info", onClose }) {
           <p className="mb-4">{message}</p>
           <p className="font-thin">{detail}</p>
         </div>
-
-        <span className="absolute top-0 bottom-0 right-0 px-4 py-3">
+        <span className="absolute top-0 bottom-0 right-0 px-4 py-3 h-fit">
           <button onClick={onClose}>
             <XIcon className="h-7 w-7" />
           </button>


### PR DESCRIPTION
The notification close symbol is blocking interactions with elements underneath it because the height of the span is filling the parent container. To solve this a custom class has been added, which also is present in newer versions of tailwind.

I added a border to these images to display the problem.
Before:
![Screenshot 2022-07-25 at 19 36 23](https://user-images.githubusercontent.com/10381866/180852772-6268c2b8-0913-440a-b696-b54b7ddd8054.png)


After:
![Screenshot 2022-07-25 at 19 40 20](https://user-images.githubusercontent.com/10381866/180852794-020740a1-d3b8-4d75-a2cf-0385d172e784.png)



