### PR TITLE
Fix #14 Control codes begin at 30, should be 31 

### DIFF
--- a/src/models/event.test.js
+++ b/src/models/event.test.js
@@ -13,7 +13,7 @@ describe("event", () => {
     const loadedEvent = Event.load(event);
 
     expect(loadedEvent.idGenerator.next()).toBe(1);
-    expect(loadedEvent.controlCodeGenerator.next()).toBe(30);
+    expect(loadedEvent.controlCodeGenerator.next()).toBe(31);
   });
 
   test("load event with controls", () => {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -64,7 +64,7 @@ export function load(data: Event): Event {
     ]),
     controlCodeGenerator: sequence([
       ...Object.keys(data.controls).map((id) => data.controls[id].code),
-      29,
+      30,
     ]),
   };
   updateAllControls(event);


### PR DESCRIPTION
Steps to reproduce bug: Create an event. Place start symbol. Reload page. Load-event is now triggered behind-the-scenes. Place a new controller. The controller gets code 30 instead of 31.

The code does match this behaviour, as the controlCodeGenerator did start at 29 (rather than 30) if no control id were present for the loaded event. `controlCodeGenerator.next()` would therefore yield the wrong result.
This PR fixes that
#14
