### PR TITLE
Bugfix and paper sizes

### DIFF
--- a/src/CourseOptions.js
+++ b/src/CourseOptions.js
@@ -87,11 +87,18 @@ export default function CourseOptions({
           index={1}
           onChange={(extent) => setPrintArea({ extent })}
         />
+        
         <div />
+        Size on paper
+        <div>Height: {((extent[3]-extent[1])*(mapScale/printScale)).toFixed(2)} mm ({(printArea.pageHeight/3.937).toFixed()} mm) </div>
+        <div>Width: {((extent[2]-extent[0])*(mapScale/printScale)).toFixed(2)} mm ({(printArea.pageWidth/3.937).toFixed()} mm) </div>  
       </div>
     </>
+    
   );
 }
+
+
 
 function ExtentInput({ extent, index, onChange }) {
   return (

--- a/src/services/ppen.js
+++ b/src/services/ppen.js
@@ -174,7 +174,7 @@ export function parsePPen(doc) {
       pageWidth: Number(printAreaTag.getAttribute("page-width")),
       pageHeight: Number(printAreaTag.getAttribute("page-height")),
       pageMargins: Number(printAreaTag.getAttribute("page-margins")),
-      pageLandscape: printAreaTag.getAttribute("page-landscape") === "true",
+      pageLandscape: printAreaTag.getAttribute("page-landscape") === "false",
     };
   }
 

--- a/src/services/ppen.js
+++ b/src/services/ppen.js
@@ -174,7 +174,9 @@ export function parsePPen(doc) {
       pageWidth: Number(printAreaTag.getAttribute("page-width")),
       pageHeight: Number(printAreaTag.getAttribute("page-height")),
       pageMargins: Number(printAreaTag.getAttribute("page-margins")),
-      pageLandscape: printAreaTag.getAttribute("page-landscape") === "false",
+      // Landscape temporarily disabled since O-Scout does not support it yet
+//      pageLandscape: printAreaTag.getAttribute("page-landscape") === "true",
+      pageLandscape: false,
     };
   }
 

--- a/src/tools/Objects.tsx
+++ b/src/tools/Objects.tsx
@@ -53,7 +53,7 @@ export default function Objects(): JSX.Element {
         cursor: "crosshair",
       });
       interaction.on("extentchangeend", ({ extent }: { extent: Extent }) => {
-        if (extent){
+        if (extent) {
           const locations = mapExtentToDescriptionLocations(
             extent,
             map.getView().getProjection(),
@@ -71,7 +71,6 @@ export default function Objects(): JSX.Element {
           setSelectedObjectId(objects[objects.length - 1].id);
           setMode("edit");
         }  
-        else alert("Single clicks are not allowed.")
       });
       map.addInteraction(interaction);
 

--- a/src/tools/Objects.tsx
+++ b/src/tools/Objects.tsx
@@ -53,22 +53,25 @@ export default function Objects(): JSX.Element {
         cursor: "crosshair",
       });
       interaction.on("extentchangeend", ({ extent }: { extent: Extent }) => {
-        const locations = mapExtentToDescriptionLocations(
-          extent,
-          map.getView().getProjection(),
-          (selectedCourse?.controls.length || 0) + 2
-        );
-        addSpecialObject(
-          {
-            kind: "descriptions",
-            locations,
-            isAllCourses: false,
-          },
-          selectedCourse.id
-        );
-        const objects = useEvent.getState().specialObjects;
-        setSelectedObjectId(objects[objects.length - 1].id);
-        setMode("edit");
+        if (extent){
+          const locations = mapExtentToDescriptionLocations(
+            extent,
+            map.getView().getProjection(),
+            (selectedCourse?.controls.length || 0) + 2
+          );
+          addSpecialObject(
+            {
+              kind: "descriptions",
+              locations,
+              isAllCourses: false,
+            },
+            selectedCourse.id
+          );
+          const objects = useEvent.getState().specialObjects;
+          setSelectedObjectId(objects[objects.length - 1].id);
+          setMode("edit");
+        }  
+        else alert("Single clicks are not allowed.")
       });
       map.addInteraction(interaction);
 

--- a/src/tools/PrintArea.js
+++ b/src/tools/PrintArea.js
@@ -10,6 +10,12 @@ import useEvent, { useMap } from "../store";
 import shallow from "zustand/shallow";
 import ExtentInteraction from "../ol/ExtentInteraction";
 import { getPrintAreaExtent } from "../models/course";
+import { printCourse } from "../services/print";
+
+import Feature from 'ol/Feature.js';
+import {Vector as VectorLayer} from 'ol/layer.js';
+import {Vector as VectorSource} from 'ol/source.js';
+import {fromExtent} from 'ol/geom/Polygon.js';
 
 export default function PrintArea() {
   const { map, mapFile } = useMap(getMap);
@@ -17,29 +23,78 @@ export default function PrintArea() {
 
   const crs = useMemo(() => mapFile?.getCrs(), [mapFile]);
 
+
   useEffect(() => {
     if (map && course) {
       const initialExtent = transformExtent(
         getPrintAreaExtent(course, crs.scale),
         (c) => toProjectedCoord(crs, c)
       );
+      
+      const PrintAreaExtentI = getPrintAreaExtent(course)
+      const check_height = (course.printArea.pageHeight/3.937)-((PrintAreaExtentI[3]-PrintAreaExtentI[1])*(15000/course.printScale))
+      const check_width = (course.printArea.pageWidth/3.937)-((PrintAreaExtentI[2]-PrintAreaExtentI[0])*(15000/course.printScale))
+    
+
+      let boxStyle;
+      
+      if (check_height < 0 || check_width < 0) {
+        boxStyle = new Style({
+          stroke: new Stroke({ color: "#FF0000", lineDash: [6, 10], width: 3 }),
+          fill: null,
+        });
+      } else {
+        boxStyle = new Style({
+          stroke: new Stroke({ color: "#444", lineDash: [6, 10], width: 3 }),
+          fill: null,
+        });
+      }
+      
       const interaction = new ExtentInteraction({
         extent: initialExtent,
         boxStyle,
         pointerStyle: new Style(),
       });
+
+      const rectCoords = []
+
+      
+      //Papersize on map. 15000 mapscale??
+      rectCoords[0] = initialExtent[0] 
+      rectCoords[1] = initialExtent[1] 
+      rectCoords[2] = initialExtent[0]+((course.printArea.pageWidth)*(course.printScale/15000)*(96*(1/25.4)))
+      rectCoords[3] = initialExtent[1]+((course.printArea.pageHeight)*(course.printScale/15000)*(96*(1/25.4)))
+  
+
+      const printLayer = new VectorLayer({
+        source: new VectorSource({
+          features: [
+            new Feature(
+              fromExtent(rectCoords),
+            ),
+          ],
+        }),
+      });
+      
+
+  
       interaction.on("extentchangeend", ({ extent }) => {
+        
         if (extent) {
           setPrintAreaExtent(
             course.id,
             transformExtent(extent, (c) => fromProjectedCoord(crs, c))
           );
+         
+          
         }
       });
       map.addInteraction(interaction);
+      map.addLayer(printLayer);
 
       return () => {
         map.removeInteraction(interaction);
+        map.removeLayer(printLayer);
       };
     }
   }, [crs, mapFile, map, course, setPrintAreaExtent]);
@@ -47,10 +102,7 @@ export default function PrintArea() {
   return null;
 }
 
-const boxStyle = new Style({
-  stroke: new Stroke({ color: "#444", lineDash: [6, 10], width: 3 }),
-  fill: null,
-});
+
 
 function getMap({ map, mapFile }) {
   return { map, mapFile };


### PR DESCRIPTION
1. Bugfix (ppen.js): Fixed issue with paper orientation when importing a Purple Pen file. When importing a Purple Pen file the orientation is incorrectly set to landscape (true). Landscape is not used by O-scout based on my findings. I changed the landscape setting to false.

2. Bugfix (objects.tsx): Fixed error message when adding a description with a single click. The function mapExtentToDescriptionLocations requires an extent, which is given by dragging an area while holding the left mouse button. I added an if-statement to check if the extent array exists. Otherwise an alert is triggered. The alert should eventually be replaced with a better solution.

3. Added information about paper size in relation to the print area in course settings (CourseOptions.js).

4. Added paper size to the map when changing the print area. It works on map with scale 1:15 000 but won't work with other map scales. Also modified the stroke around the print area to turn red when the print area exceeds the paper size (PrintArea.js). 