### PR TITLE
Bugfix normal control after finish control

### DIFF
--- a/src/tools/CreateCourse.tsx
+++ b/src/tools/CreateCourse.tsx
@@ -146,6 +146,15 @@ export default function CreateCourse(): JSX.Element {
           addControl({ ...control }, selectedCourseId);
         } else {
           const numberControls = controlsSource.getFeatures().length;
+
+          const hasFinishControl = controlsSource.getFeatures().some(
+            (feature) => feature.get("kind") === "finish"
+          );
+          
+          if (hasFinishControl) {
+            return;
+          }
+          
           const kind =
             activeModeRef.current === "Finish"
               ? "finish"


### PR DESCRIPTION
Fixed a bug that allowed a normal control to be set after the finish control was placed.