### PR TITLE
Symbols for each column

### DIFF
--- a/src/ControlDescriptionSheet.jsx
+++ b/src/ControlDescriptionSheet.jsx
@@ -232,14 +232,14 @@ function DescriptionSelector({
 
 function DescriptionList({ selected, onSelect, column }) {
   const symbols = useMemo(() => {
-    const symbols = Object.keys(DefinitionTexts);
+   const symbols = Object.keys(DefinitionTexts).filter((key) => {
+      if (column === "E") {
+        return DefinitionTexts[key].kind === "E" || DefinitionTexts[key].kind === "D";
+      }
+      return DefinitionTexts[key].kind === column;
+    });
     symbols.sort((a, b) => {
-      const aDef = DefinitionTexts[a];
-      const bDef = DefinitionTexts[b];
-      const aIsCol = aDef.kind === column ? -1 : 1;
-      const bIsCol = bDef.kind === column ? -1 : 1;
-
-      return compare(aIsCol, bIsCol) || compare(a, b);
+      return compare(a, b);
     });
     return symbols;
   }, [column]);


### PR DESCRIPTION
I crosschecked the symbols with a purple pen and it seems like kind match column for all columns except column E which contains both kind E and D. I changed from all symbols to what I hope are the correct symbols for each column. "Object size" in column F is missing. I don't know how to handle that issue.

There was an issue with svg-control-descriptions. Symbol "bend" was assigned to wrong kind in lang.json.