### PR TITLE
Name new course

### DIFF
--- a/src/Courses.jsx
+++ b/src/Courses.jsx
@@ -91,7 +91,7 @@ export default function Courses() {
               newCourse(
                 Course.create(
                   null,
-                  "New course",
+                  "Course " + courses.length,
                   [],
                   selectedCourse.printScale,
                   "normal"

--- a/src/store.ts
+++ b/src/store.ts
@@ -545,7 +545,7 @@ function createNewEvent(state?: EventState): EventState {
 
   Event.addCourse(
     event,
-    Course.create(event.idGenerator.next(), "New course", [], scale, "normal")
+    Course.create(event.idGenerator.next(), "Course 1", [], scale, "normal")
   );
 
   return {


### PR DESCRIPTION
Changed the course name as "New Course" could be misinterpreted as a button to create a new course. There is no need of +1 because "All Controls" is counted as a course.