### PR TITLE
Bugfix event map mismatch

### DIFF
--- a/src/SelectMap.jsx
+++ b/src/SelectMap.jsx
@@ -2,8 +2,7 @@ import { useRef, useState } from "react";
 import Spinner from "./ui/Spinner";
 import Button from "./ui/Button";
 import OcadTiler from "ocad-tiler";
-
-import { useMap, useNotifications } from "./store";
+import useEvent, { useMap, useNotifications } from "./store";
 import { readMap } from "./services/map";
 
 export default function SelectMap({
@@ -17,6 +16,19 @@ export default function SelectMap({
   const fileRef = useRef();
   const setMap = useMap(getSetter);
   const pushNotification = useNotifications(getPush);
+
+  const { setEventMap, mapFilename: eventMapFilename } = useEvent(
+    getEvent,
+  );
+
+  function getEvent({
+    mapFilename,
+    actions: {
+      event: { setMap: setEventMap },
+    },
+  }) {
+    return { mapFilename, setEventMap };
+  }
 
   return (
     <>
@@ -48,9 +60,15 @@ export default function SelectMap({
     setState("loading");
     try {
       const [blob] = e.target.files;
-      const map = await readMap(blob);
-      setMap(blob.name, map, new OcadTiler(map), blob);
-      onMapLoaded && onMapLoaded(map, blob.name);
+      const mapFile = await readMap(blob);
+      const mapFilename = blob.name;
+      setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);
+  
+      if (!eventMapFilename) {
+        setEventMap(mapFile, mapFilename);
+      }
+  
+      onMapLoaded && onMapLoaded(mapFile, mapFilename);
       setState("idle");
     } catch (e) {
       console.error(e);

--- a/src/StartScreen.jsx
+++ b/src/StartScreen.jsx
@@ -1,3 +1,4 @@
+
 import { useState } from "react";
 import SelectMap from "./SelectMap";
 import { readMap } from "./services/map";
@@ -10,7 +11,18 @@ export default function StartScreen() {
   const [state, setState] = useState("idle");
   const setMap = useMap(getSetter);
   const pushNotification = useNotifications(getPush);
-  const event = useEvent();
+  const { setEventMap, mapFilename: eventMapFilename } = useEvent(
+    getEvent,
+  );
+
+  function getEvent({
+    mapFilename,
+    actions: {
+      event: { setMap: setEventMap },
+    },
+  }) {
+    return { mapFilename, setEventMap };
+  }
 
   return (
     <>
@@ -72,6 +84,9 @@ export default function StartScreen() {
       const mapFile = await readMap(blob);
       const mapFilename = "Demo Map";
       setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);
+      if (!eventMapFilename) {
+        setEventMap(mapFile, mapFilename);
+      }
     } catch (e) {
       console.error(e);
       setState("error");

--- a/src/StartScreen.jsx
+++ b/src/StartScreen.jsx
@@ -48,11 +48,11 @@ export default function StartScreen() {
               </a>
               .
             </p>
-            {event.mapFilename ? (
+            {eventmapFilename ? (
               <p className="p-3 border border-indigo-600 rounded">
                 You have courses saved from a previous session using the map
                 <br />
-                <strong>{event.mapFilename}</strong>
+                <strong>{eventmapFilename}</strong>
                 <br />
                 Open this map to continue working.
               </p>


### PR DESCRIPTION
The first time you use O-Scout MapFilename will not be set when you open a map. NewEvent will not set the MapFilename. I suggest an if statement that checks if the MapFilename is set otherwise it will be set when loading map.