### PR TITLE
Bugfix empty extent print area

### DIFF
--- a/src/StartScreen.jsx
+++ b/src/StartScreen.jsx
@@ -1,57 +1,78 @@
-import { useRef, useState } from "react";
-import Spinner from "./ui/Spinner";
+
+import { useState } from "react";
+import SelectMap from "./SelectMap";
+import { readMap } from "./services/map";
+import useEvent, { useMap, useNotifications } from "./store";
 import Button from "./ui/Button";
+import Spinner from "./ui/Spinner";
 import OcadTiler from "ocad-tiler";
 
-import { useMap, useNotifications } from "./store";
-import { readMap } from "./services/map";
-
-export default function SelectMap({
-  className,
-  children,
-  type = "normal",
-  component,
-  onMapLoaded,
-}) {
+export default function StartScreen() {
   const [state, setState] = useState("idle");
-  const fileRef = useRef();
   const setMap = useMap(getSetter);
   const pushNotification = useNotifications(getPush);
+  const event = useEvent();
 
   return (
     <>
-      {component ? (
-        <div onClick={activateFilePicker}>{component}</div>
-      ) : (
-        <Button type={type} className={className} onClick={activateFilePicker}>
-          {state === "loading" && <Spinner />}
-          {children}
-        </Button>
-      )}
-      <input
-        ref={fileRef}
-        className="hidden"
-        disabled={state === "loading"}
-        type="file"
-        accept=".ocd"
-        onChange={loadMap}
-      />
+      <div className="flex h-screen bg-gray-100">
+        <div className="m-auto text-center bg-white p-24 rounded-lg shadow-md md:mt-48">
+          <h3 className="text-4xl font-bold mb-8 uppercase">O-Scout</h3>
+          <h3 className="text-4xl font-thin text-indigo-600">
+            Web-based Course Setting for Orienteering
+          </h3>
+          <div className="mx-auto flex flex-col gap-y-16 mt-16 max-w-xl text-gray-500 font-thin">
+            <p>
+              This is very much a work in progress at this point. Some things
+              are usable today, a lot of things are completely missing or very
+              roughly implemented.
+            </p>
+            <p>
+              For reporting issues, getting the code or helping out, visit{" "}
+              <a
+                className="text-indigo-400 hover:underline hover:text-indigo-600"
+                href="https://github.com/perliedman/o-scout/"
+              >
+                O-Scout at GitHub
+              </a>
+              .
+            </p>
+            {event.mapFilename ? (
+              <p className="p-3 border border-indigo-600 rounded">
+                You have courses saved from a previous session using the map
+                <br />
+                <strong>{event.mapFilename}</strong>
+                <br />
+                Open this map to continue working.
+              </p>
+            ) : null}
+          </div>
+          <div className="mt-24">
+            <span className="md:mr-4 block md:inline">
+              <SelectMap type="primary" className="text-xl w-48 h-16">
+                Open a Map
+              </SelectMap>
+            </span>
+            <span className="md:ml-4 block md:inline mt-8 md:mt-0">
+              <Button className="w-48 h-16" onClick={loadDemoMap}>
+                {state === "loading" && <Spinner className="text-indigo-600" />}
+                Open Demo Map
+              </Button>
+            </span>
+          </div>
+        </div>
+      </div>
     </>
   );
 
-  function activateFilePicker() {
-    fileRef.current.value = "";
-    setTimeout(() => fileRef.current.click());
-  }
-
-  async function loadMap(e) {
+  async function loadDemoMap() {
     setState("loading");
     try {
-      const [blob] = e.target.files;
-      const map = await readMap(blob);
-      setMap(blob.name, map, new OcadTiler(map), blob);
-      onMapLoaded && onMapLoaded(map, blob.name);
-      setState("idle");
+      const response = await window.fetch("demo-map.ocd");
+      const blob = await response.blob();
+      const mapFile = await readMap(blob);
+      const mapFilename = "Demo Map";
+      setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);
     } catch (e) {
       console.error(e);
       setState("error");

--- a/src/StartScreen.jsx
+++ b/src/StartScreen.jsx
@@ -1,77 +1,74 @@
-import { useState } from "react";
-import SelectMap from "./SelectMap";
-import { readMap } from "./services/map";
-import useEvent, { useMap, useNotifications } from "./store";
-import Button from "./ui/Button";
+import { useRef, useState } from "react";
 import Spinner from "./ui/Spinner";
+import Button from "./ui/Button";
 import OcadTiler from "ocad-tiler";
+import useEvent, { useMap, useNotifications } from "./store";
+import { readMap } from "./services/map";
 
-export default function StartScreen() {
+export default function SelectMap({
+  className,
+  children,
+  type = "normal",
+  component,
+  onMapLoaded,
+}) {
   const [state, setState] = useState("idle");
+  const fileRef = useRef();
   const setMap = useMap(getSetter);
   const pushNotification = useNotifications(getPush);
-  const event = useEvent();
+
+  const { setEventMap, mapFilename: eventMapFilename } = useEvent(
+    getEvent,
+  );
+
+  function getEvent({
+    mapFilename,
+    actions: {
+      event: { setMap: setEventMap },
+    },
+  }) {
+    return { mapFilename, setEventMap };
+  }
 
   return (
     <>
-      <div className="flex h-screen bg-gray-100">
-        <div className="m-auto text-center bg-white p-24 rounded-lg shadow-md md:mt-48">
-          <h3 className="text-4xl font-bold mb-8 uppercase">O-Scout</h3>
-          <h3 className="text-4xl font-thin text-indigo-600">
-            Web-based Course Setting for Orienteering
-          </h3>
-          <div className="mx-auto flex flex-col gap-y-16 mt-16 max-w-xl text-gray-500 font-thin">
-            <p>
-              This is very much a work in progress at this point. Some things
-              are usable today, a lot of things are completely missing or very
-              roughly implemented.
-            </p>
-            <p>
-              For reporting issues, getting the code or helping out, visit{" "}
-              <a
-                className="text-indigo-400 hover:underline hover:text-indigo-600"
-                href="https://github.com/perliedman/o-scout/"
-              >
-                O-Scout at GitHub
-              </a>
-              .
-            </p>
-            {event.mapFilename ? (
-              <p className="p-3 border border-indigo-600 rounded">
-                You have courses saved from a previous session using the map
-                <br />
-                <strong>{event.mapFilename}</strong>
-                <br />
-                Open this map to continue working.
-              </p>
-            ) : null}
-          </div>
-          <div className="mt-24">
-            <span className="md:mr-4 block md:inline">
-              <SelectMap type="primary" className="text-xl w-48 h-16">
-                Open a Map
-              </SelectMap>
-            </span>
-            <span className="md:ml-4 block md:inline mt-8 md:mt-0">
-              <Button className="w-48 h-16" onClick={loadDemoMap}>
-                {state === "loading" && <Spinner className="text-indigo-600" />}
-                Open Demo Map
-              </Button>
-            </span>
-          </div>
-        </div>
-      </div>
+      {component ? (
+        <div onClick={activateFilePicker}>{component}</div>
+      ) : (
+        <Button type={type} className={className} onClick={activateFilePicker}>
+          {state === "loading" && <Spinner />}
+          {children}
+        </Button>
+      )}
+      <input
+        ref={fileRef}
+        className="hidden"
+        disabled={state === "loading"}
+        type="file"
+        accept=".ocd"
+        onChange={loadMap}
+      />
     </>
   );
 
-  async function loadDemoMap() {
+  function activateFilePicker() {
+    fileRef.current.value = "";
+    setTimeout(() => fileRef.current.click());
+  }
+
+  async function loadMap(e) {
     setState("loading");
     try {
-      const response = await window.fetch("demo-map.ocd");
-      const blob = await response.blob();
+      const [blob] = e.target.files;
       const mapFile = await readMap(blob);
-      const mapFilename = "Demo Map";
-      setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);
+      const mapFilename = blob.name;
+      setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);  
+      if (!eventMapFilename) {
+        setEventMap(mapFile, mapFilename);
+      }
+  
+      onMapLoaded && onMapLoaded(mapFile, mapFilename);
+      setState("idle");
     } catch (e) {
       console.error(e);
       setState("error");

--- a/src/StartScreen.jsx
+++ b/src/StartScreen.jsx
@@ -2,7 +2,8 @@ import { useRef, useState } from "react";
 import Spinner from "./ui/Spinner";
 import Button from "./ui/Button";
 import OcadTiler from "ocad-tiler";
-import useEvent, { useMap, useNotifications } from "./store";
+
+import { useMap, useNotifications } from "./store";
 import { readMap } from "./services/map";
 
 export default function SelectMap({
@@ -16,19 +17,6 @@ export default function SelectMap({
   const fileRef = useRef();
   const setMap = useMap(getSetter);
   const pushNotification = useNotifications(getPush);
-
-  const { setEventMap, mapFilename: eventMapFilename } = useEvent(
-    getEvent,
-  );
-
-  function getEvent({
-    mapFilename,
-    actions: {
-      event: { setMap: setEventMap },
-    },
-  }) {
-    return { mapFilename, setEventMap };
-  }
 
   return (
     <>
@@ -60,14 +48,9 @@ export default function SelectMap({
     setState("loading");
     try {
       const [blob] = e.target.files;
-      const mapFile = await readMap(blob);
-      const mapFilename = blob.name;
-      setMap(mapFilename, mapFile, new OcadTiler(mapFile), blob);  
-      if (!eventMapFilename) {
-        setEventMap(mapFile, mapFilename);
-      }
-  
-      onMapLoaded && onMapLoaded(mapFile, mapFilename);
+      const map = await readMap(blob);
+      setMap(blob.name, map, new OcadTiler(map), blob);
+      onMapLoaded && onMapLoaded(map, blob.name);
       setState("idle");
     } catch (e) {
       console.error(e);

--- a/src/tools/PrintArea.jsx
+++ b/src/tools/PrintArea.jsx
@@ -32,9 +32,13 @@ export default function PrintArea() {
   useEffect(() => {
     if (map && course) {
       const paperExtent = getPrintAreaExtent(course, crs.scale);
-      const initialExtent = transformExtent(paperExtent, (c) =>
+      const validExtent = paperExtent.every((value) => isFinite(value)) 
+      ? paperExtent 
+      : [-40, -60, 60, 40];
+      const initialExtent = transformExtent(validExtent, (c) =>
         toProjectedCoord(crs, c)
       );
+
 
       const { pageWidth, pageHeight } = course.printArea;
       const pageSizeMm = [


### PR DESCRIPTION
An error message will appear if you do not create any control before clicking on the 'Area' tool. This will create a print area if the printAreaExtent is empty. A potential issue with this is that the area may be placed outside the map.