### PR TITLE
Persist OCAD map file in localstorage between sessions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import Map from "./MapComponent";
 import StartScreen from "./StartScreen";
 import Sidebar from "./Sidebar";
-import useEvent, { useMap, useNotifications } from "./store";
+import useEvent, { useMap, useNotifications, useSavedMap } from "./store";
 import Toolbar from "./Toolbar";
 import Alert from "./ui/Alert";
 import { ErrorBoundary } from "react-error-boundary";
@@ -9,6 +9,7 @@ import Button from "./ui/Button";
 
 function App() {
   const mapFile = useMap(getMap);
+  const hasLoadedSavedMap = useSavedMap();
   const newEvent = useEvent(getNewEvent);
   const { notifications, popNotification } = useNotifications(getNotifications);
   const { type, message, detail } =
@@ -22,9 +23,9 @@ function App() {
           <Sidebar />
           <Toolbar />
         </>
-      ) : (
+      ) : hasLoadedSavedMap ? (
         <StartScreen />
-      )}
+      ) : null}
       {message ? (
         <div className="absolute top-0">
           <div className="z-20">

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,11 +101,20 @@ export const useMap = create<MapState>((set) => ({
       const reader = new FileReader();
       reader.readAsDataURL(mapFileBlob);
       reader.onloadend = () => {
-        localStorage.setItem(
-          mapMetadataKey,
-          JSON.stringify({ mapFilename } satisfies MapMetadata)
-        );
-        localStorage.setItem(mapBlobKey, reader.result as string);
+        try {
+          localStorage.setItem(
+            mapMetadataKey,
+            JSON.stringify({ mapFilename } satisfies MapMetadata)
+          );
+          localStorage.setItem(mapBlobKey, reader.result as string);
+        } catch (e) {
+          // Storage failed, likely because data is too large,
+          // clear any data we have there to avoid corrupt state when app is
+          // reloaded
+          console.error(e);
+          localStorage.removeItem(mapMetadataKey);
+          localStorage.removeItem(mapBlobKey);
+        }
       };
     }),
   setMapInstance: (map) =>


### PR DESCRIPTION
This is an experiment with storing the last used OCAD map in local storage, so the user will not have to find the map on disk every time they return to the app.

From some quick experiments, it looks like this works, but I'm not sure if the maps are really too big to expect local storage to hold them ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria) says 5-10 MB, which seems to be close to what normal size OCAD maps are, in my experience).

